### PR TITLE
Improve control of buildsystem and compiler options

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -25,7 +25,7 @@ FFLAGS := -fd-lines-as-comments -fbackslash -std=legacy -static-libgfortran
 CFLAGS := -static-libgfortran
 MACHINE_DEP := machine_dep.g77
 LIB_NAME := hole.a
-AR := ar -rcv
+AR := ar
 RANLIB := ranlib
 #L_ARCH   = $(ARCH)
 #LIB_NAME = d-$(L_ARCH).a
@@ -161,12 +161,12 @@ $(2DMAP_D):
 src: $(LIB_NAME)
 
 $(LIB_NAME): $(FILES) 
-	$(AR) $(LIB_NAME) $(FILES)  
+	$(AR) -rcv $(LIB_NAME) $(FILES)  
 	$(RANLIB) $(LIB_NAME)
 
 .f.o:
 	$(FC) $(FFLAGS) -c $*.f
-	$(AR) $(LIB_NAME) $*.o
+	$(AR) -rcv $(LIB_NAME) $*.o
 
 clean:
 	- rm -f *.o

--- a/src/Makefile
+++ b/src/Makefile
@@ -20,8 +20,8 @@ DATA_DIR:= $(PREFIX)/share/hole2#
 FC := gfortran
 # FC is used by makver.exe
 CC := gcc
-FFLAGS := -fd-lines-as-comments -fbackslash -std=legacy -static-libgfortran
-CFLAGS := -static-libgfortran
+FFLAGS += -fd-lines-as-comments -fbackslash -std=legacy -static-libgfortran
+CFLAGS += -static-libgfortran
 MACHINE_DEP := machine_dep.g77
 LIB_NAME := hole.a
 AR := ar

--- a/src/Makefile
+++ b/src/Makefile
@@ -19,7 +19,6 @@ DATA_DIR:= $(PREFIX)/share/hole2#
 #
 FC := gfortran
 # FC is used by makver.exe
-export FC
 CC := gcc
 FFLAGS := -fd-lines-as-comments -fbackslash -std=legacy -static-libgfortran
 CFLAGS := -static-libgfortran
@@ -27,6 +26,11 @@ MACHINE_DEP := machine_dep.g77
 LIB_NAME := hole.a
 AR := ar
 RANLIB := ranlib
+
+export FC
+export FFLAGS
+export LFLAGS
+export AR
 #L_ARCH   = $(ARCH)
 #LIB_NAME = d-$(L_ARCH).a
 #FFLAGS = $(OPTFLAGS)
@@ -193,11 +197,12 @@ machine_dep.f:
 	ln -s $(MACHINE_DEP) machine_dep.f
 
 makver.exe: makver.f
-	$(FC) makver.f -o makver.exe
+	$(FC) $(FFLAGS) $(LFLAGS) makver.f -o makver.exe
 
 # makver.exe uses environment variable FC to set Fortran compiler
 # (note: 256 character limit to the path length of FC)
-RUN_MAKVER := FC=$(FC) ./makver.exe
+# makver uses environment variables FC, AR, FFLAGS, LFLAGS
+RUN_MAKVER := ./makver.exe
 
 vertim.f: makver.exe
 	$(RUN_MAKVER)

--- a/src/makver.f
+++ b/src/makver.f
@@ -22,6 +22,9 @@ C limitations under the License.
       CHARACTER*300 HoleRestrict
 ! Fortran compiler in environment variable FC      
       CHARACTER*256 FC
+      CHARACTER*256 AR
+      CHARACTER*1024 FFLAGS
+      CHARACTER*1024 LFLAGS
 ! build information for proper release from environment variables
       CALL GET_ENVIRONMENT_VARIABLE( "HoleVersion", HoleVersion)
       CALL GET_ENVIRONMENT_VARIABLE( "HoleDate", HoleDate)
@@ -30,8 +33,13 @@ C limitations under the License.
       CALL GET_ENVIRONMENT_VARIABLE( "HoleRestrict", HoleRestrict)
       
       CALL GET_ENVIRONMENT_VARIABLE( "FC", FC)
+      CALL GET_ENVIRONMENT_VARIABLE( "AR", AR)
+      CALL GET_ENVIRONMENT_VARIABLE( "FFLAGS", FFLAGS)
+      CALL GET_ENVIRONMENT_VARIABLE( "LFLAGS", LFLAGS)
       IF (LEN_TRIM(FC).LE.1) FC = "gfortran"
-      
+      IF (LEN_TRIM(FC).LE.1) AR = "ar"
+      IF (LEN_TRIM(FC).LE.1) FFLAGS = ""
+      IF (LEN_TRIM(FC).LE.1) LFLAGS = ""
       IF (LEN_TRIM(HoleVersion).LE.1) HoleVersion = 
      &"SOURCE DISTRIBUTION"
       IF (LEN_TRIM(HoleDate).LE.1) HoleDate = "?"
@@ -69,8 +77,10 @@ C limitations under the License.
       CLOSE(1)
 
 ! compile this s/r need to know the Fortran compiler: get from env var FC
-      call system(TRIM(FC) // ' -c -O vertim.f')
+      call system(TRIM(FC) // ' ' // TRIM(FFLAGS) // ' ' //
+     &            TRIM(LFLAGS) // ' ' //
+     &            ' -c -O vertim.f')
 ! hole version
-      call system('ar rv hole.a vertim.o')
+      call system(TRIM(AR) // ' rv hole.a vertim.o')
       call system('rm vertim.o')
       end


### PR DESCRIPTION
* `makver.f` now looks for `FFLAGS`, `LFLAGS`, and `AR` through the environment
* Makefile exports the above environment variables